### PR TITLE
add meshabox_with_gridoptions.m and its demo file

### DIFF
--- a/meshabox_with_gridoptions.m
+++ b/meshabox_with_gridoptions.m
@@ -1,0 +1,75 @@
+function [node,elem,face]=meshabox_with_gridoptions(p0,p1,maxvol, maxradiustoedge, minangle,  nodesize)
+% 
+% [node,elem,face]=meshabox_with_gridoptions(p0,p1,maxvol,aspectratio,minangle,nodesize)
+%
+% This function extends the capabilities of the meshabox() function from
+% ISO2MESH library to allow for more specific mesh controls sent to tetgen.
+%
+% input:
+%   p0: coordinate of one corner of bounding box
+%   p1: coordinate of opposit corner of bounding box
+%   maxvol: maximal volume of a tetrahedral element.  ~ h^3
+%   maxradiustoedge: maximal value allowed of radius(T) / min_{e in T} |e|
+%       This is a way of measuring quality of tetrahedron.  The default is 
+%       2, but it is possible to specify (and still converge) down to 1.2 
+%       or 1.414. While it isn't guaranteed to give good quality for small
+%       ratio since slivers can have as small as 0.7, it is a decent 
+%       measure.  With angle conditions, it could be better.
+%   minangle: minimal dihedral angle of an element.  default = 0, but can
+%       converge up to 18.  This is not guaranteed to be enforced, but the
+%       optimizer will try.  If the angle is too high, the optimization
+%       subroutine may not converge, so try lowering the value if this
+%       happens.
+%   nodesize = 1 or an 8x1 array, size of the element near each vertex
+%
+% output:
+%   node: node coordinates, 3 columns for x, y and z respectively
+%   face: integer array with dimensions of NB x 3, each row represents
+%         a surface mesh face element 
+%   elem: integer array with dimensions of NE x 4, each row represents
+%         a tetrahedron 
+%
+%  example:  
+%
+%     p0 = [0,0,0];
+%     p1 = [1,1,1];
+%     min_volume = (0.1)^3;
+%     radius_to_edge_ratio = 1.2;
+%     min_angle = 18;
+%     nodesize = 1;
+% 
+%     [node,elem,face]=meshabox_with_gridoptions(p0,p1,min_volume,...
+%                                radius_to_edge_ratio,min_angle,nodesize);
+%
+%
+% Author: Spencer Patty
+% Dec 29, 2015
+
+if(nargin<3)
+   maxvol = 1;
+   maxradiustoedge = 1.414;
+   minangle = 0;
+   nodesize = 1;
+elseif (nargin < 4)
+   maxradiustoedge = 1.414;
+   minangle = 0;
+   nodesize = 1;
+elseif (nargin < 5)
+   minangle = 0;
+   nodesize = 1;
+elseif (nargin < 6)
+   nodesize = 1;
+end
+
+% should add some assertions
+% assert  0 <= aspectratio <= 2  but in reality no smaller than 1.2
+% assert  30 > minangle > 0 but in reality no larger than 18.
+% assert maxvol > 0 
+
+% define the options that will be picked up in the surf2mesh function
+ISO2MESH_TETGENOPT = ['-A -q' num2str(maxradiustoedge) '/' num2str(minangle) ...
+                      ' -a' num2str(maxvol) ' -V']; 
+                  
+[node,elem,face]=surf2mesh([],[],p0,p1,1,maxvol,[],[],nodesize);
+elem=elem(:,1:4);
+face=face(:,1:3);

--- a/sample/demo_meshabox_with_gridoptions.m
+++ b/sample/demo_meshabox_with_gridoptions.m
@@ -1,0 +1,20 @@
+
+
+% where to store the tetgen files
+ISO2MESH_TEMP = '/Users/srobertp/software/geometric_pdes_matlab/tmp_iso2mesh_files';
+% prefix to tetgen filenames
+ISO2MESH_SESSION = 'srp_';
+
+p0 = [0,0,0];
+p1 = [1,1,1];
+min_volume = (0.1)^3; 
+radius_to_edge_ratio = 1.2; % default = 1.414
+min_angle = 18; % default = 0
+nodesize = 1; % default = 1
+
+[node,elem,face]=meshabox_with_gridoptions(p0,p1,min_volume,radius_to_edge_ratio,min_angle,nodesize);
+
+
+%% visualize the resulting mesh
+plotmesh(node,face(:,1:3));
+axis equal;

--- a/sample/demo_meshabox_with_gridoptions.m
+++ b/sample/demo_meshabox_with_gridoptions.m
@@ -1,9 +1,22 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   demo script for mesh generation from a bounding box
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%% preparation
+% user must add the path of iso2mesh to matlab path list
+% addpath('../');
 
-% where to store the tetgen files
-ISO2MESH_TEMP = '/Users/srobertp/software/geometric_pdes_matlab/tmp_iso2mesh_files';
-% prefix to tetgen filenames
-ISO2MESH_SESSION = 'srp_';
+% user need to add the full path to .../iso2mesh/bin directory
+% to windows/Linux/Unix PATH environment variable
+
+%% create mesh
+
+% another option for setting temporary tetgen file locations
+% % where to store the tetgen files
+% ISO2MESH_TEMP = '/Users/srobertp/software/geometric_pdes_matlab/tmp_iso2mesh_files';
+% % prefix to tetgen filenames
+% ISO2MESH_SESSION = 'srp_';
+
 
 p0 = [0,0,0];
 p1 = [1,1,1];


### PR DESCRIPTION
The following file could be a useful one to be able to fine tune the optimization parameters for mesh quality being sent into the Tetgen mesh creater.  Those of us that may be using this for finite element meshes, often want to see the quality of the meshes and maybe have some control over the dihedral angles and radius to edge ratios...
