### PR TITLE
Calling mwpath with no inputs

### DIFF
--- a/mwpath.m
+++ b/mwpath.m
@@ -22,6 +22,10 @@ function tempname=mwpath(fname)
 % -- this function is part of iso2mesh toolbox (http://iso2mesh.sf.net)
 %
 
+if (nargin < 1) || isempty(fname)
+    fname = '';
+end
+
 p=getvarfrom({'caller','base'},'ISO2MESH_TEMP');
 session=getvarfrom({'caller','base'},'ISO2MESH_SESSION');
 


### PR DESCRIPTION
Calling mwpath with no inputs crashed when trying to reach variable "fname".
Some functions (eg. surfboolean) call this function without parameters to get only a temporary folder.