### PR TITLE
Fix #68 - saveinr() not working for single volumes.

### DIFF
--- a/saveinr.m
+++ b/saveinr.m
@@ -27,7 +27,7 @@ elseif(strcmp(dtype,'uint16'))
    btype='unsigned fixed';
    dtype='uint16';
    bitlen=16;	
-elseif(strcmp(dtype,'float'))
+elseif(strcmp(dtype,'single'))
    btype='float';
    dtype='float';
    bitlen=32;


### PR DESCRIPTION
The dtype of `vol` was compared against `float` instead of 'single'. Neither Octave nor Matlab report `class(vol)` for single precision `vol` as 'float' but as 'single', instead.
Changed the comparision to 'single'.
This fixes issue #68.