### PR TITLE
Include faces into removeisolatednode function

### DIFF
--- a/removeisolatednode.m
+++ b/removeisolatednode.m
@@ -1,6 +1,6 @@
-function [no,el]=removeisolatednode(node,elem)
+function [no,el,fa]=removeisolatednode(node,elem,face)
 %
-% [no,el]=removeisolatednode(node,elem)
+% [no,el,fa]=removeisolatednode(node,elem,face)
 %
 % remove isolated nodes: nodes that are not included in any element
 %
@@ -9,10 +9,12 @@ function [no,el]=removeisolatednode(node,elem)
 % input:
 %     node: list of node coordinates
 %     elem: list of elements of the mesh, can be a regular array or a cell array for PLCs
+%     face: list of triangular surface face
 %
 % output:
 %     no: node coordinates after removing the isolated nodes
 %     el: element list of the resulting mesh
+%     fa: face list of the resulting mesh
 %
 % -- this function is part of iso2mesh toolbox (http://iso2mesh.sf.net)
 %
@@ -33,6 +35,13 @@ if(~iscell(elem))
     el=oid(elem);             % element list in the new index
 else
     el=cellfun(@(x) oid(x), elem,'UniformOutput',false);
+end
+if(nargin>=3)
+  if(~iscell(face))
+      fa=oid(face);             % face list in the new index
+  else
+      fa=cellfun(@(x) oid(x), face,'UniformOutput',false);
+  end
 end
 no=node;                  
 no(idx,:)=[];             % remove the isolated nodes


### PR DESCRIPTION
After meshing often removeisolatednode(node, elem) is called to get rid of isolated nodes. So far, removeisolatednode was only updating the according elem list. Now it includes updating the faces, too, which is needed to use other iso2mesh functions like plotmesh (including the different tissue coloring).