### PR TITLE
Fixed bug in 'int16' data reading.

### DIFF
--- a/nii2jnii.m
+++ b/nii2jnii.m
@@ -177,7 +177,7 @@ type2str = {
             'uint8'    0   % unknown                       %
             'uint8'    0   % binary (1 bit/voxel)          %
             'uint8'    1   % unsigned char (8 bits/voxel)  %
-            'uint16'   1   % signed short (16 bits/voxel)  %
+            'int16'   1   % signed short (16 bits/voxel)  %
             'int32'    1   % signed int (32 bits/voxel)    %
             'single'   1   % float (32 bits/voxel)         %
             'single'   2   % complex (64 bits/voxel)       %


### PR DESCRIPTION
Hi,
I encountered a bug when trying to use `brain2mesh` to build a mesh from the ICBM 2009c Nonlinear Asymmetric Atlas ([available here](https://nist.mni.mcgill.ca/icbm-152-nonlinear-atlases-2009/)). This issue occurs when reading NIfTI files containing `int16` data.

To reproduce the error you can use the following Docker image: [aldoclemente/iso2mesh-bug](https://hub.docker.com/r/aldoclemente/iso2mesh-bug). 

### Steps to reproduce the issue

Pull the Docker image and run the container:
```
docker run --rm -ti aldoclemente/iso2mesh-bug /bin/bash
```
Inside the container, you will find four directories:
 
 * `~/octave/`: contains the required packages to run `brain2mesh`. 
 	
 * `~/mni_icbm152_nlin_asym_09c/`: contains the nifti data.
 
 * `~/jnii_uint16/`: contains the `.jnii` data obtained using the older version of `nii2jnii`(created with `~/mni_icbm152_nlin_asym_09c_jnii_uint16.m`).
 
 * `~/jnii/`: : contains the `.jnii` data obtained using the newer version of `nii2jnii`(created with `~/mni_icbm152_nlin_asym_09c_jnii.m`).

You can run the script that reproduces the error:
``` 
cd && octave script_broken.m
```

To test the corrected version of `nii2jnii`, run:
```
cd && octave script.m 
```

You can inspect the output matrices (nodes, elements, and faces) with:
```
head nodes.txt 
head elements.txt
head faces.txt
```

**Additional note** 

While running Octave in Docker, I encountered another minor issue at **line 239** of `nii2jnii.m`. 
To ensure proper execution, I had to modify this line in both versions of `iso2mesh`:

original:
```
nii.img = typecast(gzdata(nii.hdr.vox_offset + 1:nii.hdr.vox_offset + imgbytenum), nii.datatype);
```

modified:
```
nii.img = typecast(gzdata(double(nii.hdr.vox_offset + 1):double(nii.hdr.vox_offset + imgbytenum)), nii.datatype);
```
I also observed this behaviour when using the [gnuoctave/octave](https://hub.docker.com/r/gnuoctave/octave) Docker image.
However, I did not observe this issue when running Octave on my local machine, so I did not include it in the pull request.

Let me know if you need any further details!

Kind regards,
Aldo