### PR TITLE
[bug] fix #87, qmeshcut reshape error

### DIFF
--- a/qmeshcut.m
+++ b/qmeshcut.m
@@ -200,7 +200,8 @@ tripatch = reshape(tripatch(find(tripatch)), [3, length(tricut)])';
 % convhulln)
 
 quadpatch = emap(quadcut, :)';
-quadpatch = reshape(quadpatch(find(quadpatch)), [4, length(quadpatch)])';
+numquads = length(quadcut);
+quadpatch=reshape(quadpatch(find(quadpatch)),[4,numquads])';
 
 % combine the two sets to create the final facedata
 % using the matching-tetrahedra algorithm as shown in


### PR DESCRIPTION
This is a simple bugfix to address the https://github.com/fangq/iso2mesh/issues/87 error with quadrilateral counts when taking cross sections.